### PR TITLE
Fix Swift 5 optional bindings

### DIFF
--- a/Sources/SwiftTerm/main.swift
+++ b/Sources/SwiftTerm/main.swift
@@ -86,7 +86,7 @@ struct ArgumentParser {
             return .list
         }
 
-        guard let path else {
+        guard let path = path else {
             return nil
         }
 
@@ -155,7 +155,7 @@ func listSerialPorts() -> [(path: String, name: String?)] {
             name = cfName
         }
 
-        if let path {
+        if let path = path {
             result.append((path, name))
         }
 
@@ -400,7 +400,7 @@ func main() {
             print("No serial ports found")
         } else {
             for (path, name) in ports {
-                if let name {
+                if let name = name {
                     print("\(path) - \(name)")
                 } else {
                     print(path)


### PR DESCRIPTION
## Summary
- replace the shorthand guard binding with an explicit binding so Swift 5 can compile the CLI argument parser
- convert shorthand optional bindings in port listing and printing to explicit bindings for Swift 5 compatibility

## Testing
- `swift build` *(fails on Linux because the IOKit module is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c13462c483288e27e399c31d1156